### PR TITLE
fix(credential-password): allow password min length below default 8

### DIFF
--- a/plugins/credential-password/constants.go
+++ b/plugins/credential-password/constants.go
@@ -4,6 +4,7 @@ import "github.com/thecodearcher/limen"
 
 const (
 	defaultMinPasswordLength        = 8
+	minAllowedPasswordLength        = 4
 	defaultPasswordRequireUppercase = true
 	defaultPasswordRequireNumbers   = true
 	defaultPasswordRequireSymbols   = false

--- a/plugins/credential-password/plugin.go
+++ b/plugins/credential-password/plugin.go
@@ -105,8 +105,8 @@ func (p *credentialPasswordPlugin) Initialize(core *limen.LimenCore) error {
 		return fmt.Errorf("config is required")
 	}
 
-	if p.config.passwordMinLength < defaultMinPasswordLength {
-		return fmt.Errorf("password min length must be at least 4")
+	if p.config.passwordMinLength < minAllowedPasswordLength {
+		return fmt.Errorf("password min length must be at least %d", minAllowedPasswordLength)
 	}
 
 	return nil


### PR DESCRIPTION
Refs #30

Initialize compared the configured password min length against
defaultMinPasswordLength (8) while the error message claimed a floor of 4,
so valid lower values like WithPasswordMinLength(6) were rejected.

- Add minAllowedPasswordLength (4) as the true absolute floor, distinct
  from the default of 8
- Validate the configured value against that floor, accepting length >= 4
- Format the error message with the actual constant instead of a
  hardcoded "4"

Default behavior (8) is unchanged.