### PR TITLE
feat: use utc timestamp during migration

### DIFF
--- a/cmd/limen/migration.go
+++ b/cmd/limen/migration.go
@@ -19,7 +19,7 @@ type Migration struct {
 
 func generateMigrations(db *sql.DB, driver Driver, config *cliConfig) ([]Migration, error) {
 	migrations := make([]Migration, 0, len(config.Schemas))
-	baseTime := time.Now()
+	baseTime := time.Now().UTC()
 
 	introspector := newSchemaIntrospector(db, driver)
 	tableNames := make([]string, 0, len(config.Schemas))


### PR DESCRIPTION
# Issue

Both `golang-migrate` and `goose` use timestamps from UTC when generating migration files, while limen uses timestamp from current timezone. This simple change makes limen migrations not go out of order if user is at different timezone than UTC and has generated migrations using both `golang-migrate`/`goose` and `limen`.